### PR TITLE
Bumping version for compatibility with Epinio 0.3.1

### DIFF
--- a/buildpack.yml
+++ b/buildpack.yml
@@ -1,2 +1,2 @@
 mri:
-  version: 2.6.7
+  version: 2.6.8


### PR DESCRIPTION
I was getting this error when pushing to epinio 0.3.1, so I bumped the version and it worked fine again. 

> 🕞  [80f1b2241b733021-stage-7rsnh-pod-7zrzc] step-create failed to satisfy "ruby" dependency version constraint "2.6.7": no compatible versions on "io.buildpacks.stacks.bionic" stack. Supported versions are: [2.6.8, 2.6.9, 2.7.4, 2.7.5, 3.0.2, 3.0.3] 
🕞  [80f1b2241b733021-stage-7rsnh-pod-7zrzc] step-create ERROR: failed to build: exit status 1 
🕞  [80f1b2241b733021-stage-7rsnh-pod-7zrzc] step-results 2021/12/21 12:39:18 Skipping step because a previous step failed 
2021/12/21 13:39:20 EpinioApiClient "msg"="response is not StatusOK" "error"="Internal Server Error: Tasks Completed: 4 (Failed: 1, Cancelled 0), Skipped: 0" "status"=500 
2