### PR TITLE
Update to Ruby 3.2 for buildpack update compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '>=3.1'
+ruby '>=3.2'
 
 gem 'sinatra', '>=2.2.0'
 gem 'thin', '>=1.8.1'
@@ -8,3 +8,8 @@ gem 'maruku'
 gem 'i18n'
 gem 'rexml'
 gem 'rack-ssl-enforcer'
+
+gem "rackup", "~> 2.2"
+gem "puma", "~> 6.6"
+
+gem "ostruct", "~> 0.6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,46 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    concurrent-ruby (1.1.10)
+    base64 (0.3.0)
+    concurrent-ruby (1.3.5)
     daemons (1.4.1)
     eventmachine (1.2.7)
-    i18n (1.10.0)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    logger (1.7.0)
     maruku (0.7.3)
-    mustermann (1.1.1)
+    mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
+    nio4r (2.7.4)
+    ostruct (0.6.2)
+    puma (6.6.0)
+      nio4r (~> 2.0)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-ssl-enforcer (0.2.9)
-    rexml (3.2.5)
+    rackup (2.2.1)
+      rack (>= 3)
+    rexml (3.4.1)
     ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    thin (1.8.1)
+    thin (2.0.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    tilt (2.0.10)
+      logger
+      rack (>= 1, < 4)
+    tilt (2.6.1)
 
 PLATFORMS
   ruby
@@ -32,13 +48,16 @@ PLATFORMS
 DEPENDENCIES
   i18n
   maruku
+  ostruct (~> 0.6.2)
+  puma (~> 6.6)
   rack-ssl-enforcer
+  rackup (~> 2.2)
   rexml
   sinatra (>= 2.2.0)
   thin (>= 1.8.1)
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.2.3p157
 
 BUNDLED WITH
-   2.3.14
+   2.4.20

--- a/web.rb
+++ b/web.rb
@@ -6,7 +6,9 @@ require 'rack/ssl-enforcer'
 configure do
   use Rack::SslEnforcer if ENV['FORCE_SSL']
   I18n.enforce_available_locales = true
-  I18n.load_path = Dir[File.join(settings.root, 'locales', '*.yml')]
+  I18n.load_path += Dir[File.join(settings.root, 'locales', '*.yml')]
+  # I18n.available_locales = Dir[File.join(settings.root, 'locales', '*.yml')].map { |f| File.basename(f, '.yml').to_sym }
+  # I18n.available_locales = [:en, :pt]
   I18n.backend.load_translations
   I18n.default_locale = :en
 end


### PR DESCRIPTION
This updates gems for buildpack updates.
Prior, the process would complain about missing gems at runtime. (when updating to 0.3.490)